### PR TITLE
Sort repositories by update time

### DIFF
--- a/internal/github/repository/repository.go
+++ b/internal/github/repository/repository.go
@@ -65,6 +65,8 @@ func (r *Repo) ListRepositories(ctx context.Context, limit int) ([]GithubReposit
 		queryParams: map[string]string{
 			"visibility": "all", // default
 			"per_page":   strconv.Itoa(limit),
+			"sort":       "updated",
+			"direction":  "desc", //default
 		},
 	})
 	if err != nil {

--- a/internal/github/usecase/types.go
+++ b/internal/github/usecase/types.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"time"
+
 	pw "github.com/termkit/gama/pkg/workflow"
 )
 
@@ -17,6 +19,7 @@ type GithubRepository struct {
 	Private       bool
 	DefaultBranch string
 	Stars         int
+	LastUpdated   time.Time
 
 	Workflows []Workflow
 	// We can add more fields here

--- a/internal/github/usecase/usecase.go
+++ b/internal/github/usecase/usecase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	gr "github.com/termkit/gama/internal/github/repository"
@@ -48,6 +49,10 @@ func (u useCase) ListRepositories(ctx context.Context, input ListRepositoriesInp
 		}
 	}
 
+	slices.SortFunc(result, func(a, b GithubRepository) int {
+		return int(b.LastUpdated.Unix() - a.LastUpdated.Unix())
+	})
+
 	return &ListRepositoriesOutput{
 		Repositories: result,
 	}, errors.Join(resultErrs...)
@@ -72,6 +77,7 @@ func (u useCase) workerListRepositories(ctx context.Context, repository gr.Githu
 		Stars:         repository.StargazersCount,
 		Private:       repository.Private,
 		DefaultBranch: repository.DefaultBranch,
+		LastUpdated:   repository.UpdatedAt,
 		Workflows:     workflows,
 	}
 }


### PR DESCRIPTION
Request repositories sorting by 'updated', using `sort` param:
```
"sort": "updated",
"direction": "desc",
```

Then sort the `[]GithubRepository` after getting workflow. We need this additional slice sort, since we get workflows concurrently.
