### PR TITLE
Fix "toolchain not available" error when `make build`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/termkit/gama
 
-go 1.22
+go 1.22.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f h1:MvTmaQdww/z0Q4wrYjDSCcZ78NoftLQyHBSLW/Cx79Y=
-github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
 github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Overview

- I got an error message "go: download go1.22 for darwin/arm64: toolchain not available" when running `make build`, so I fixed it.
  - Issue: https://github.com/termkit/gama/issues/54
- Error Cause: Missing patch version suffix.
  - Related issue: https://github.com/golang/go/issues/66175
- Solution: Fix go version listed in go.mod from 1.22 to 1.22.1.
  - Also ran `go mod tidy` and updated go.sum.

## Confirmation of operation

- I confirmed that there is no error when executing `make build`.
- Executed the generated binary and confirmed that the application starts without any problem.