### PR TITLE
Update README.md with notes for better GITHUB_TOKEN handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Alternatively, you can use an environment variable:
 GITHUB_TOKEN="<your github token>" gama
 ```
 
+You can also make it an alias for a better experience:
+
+```bash
+alias gama='GITHUB_TOKEN="<your github token>" command gama'
+```
+
 If you have the [GitHub CLI](https://cli.github.com/) installed, you automatically insert the var via:
 
 ```bash
@@ -55,6 +61,11 @@ GITHUB_TOKEN="$(gh auth token)" gama
 ```
 
 This will skip needing to generate a token via the GitHub website.
+
+> [!WARNING]
+> For security reasons, you should not `export` your token globally in your shell.
+> That would make it available to any app that can read environment variables.
+> You should avoid committing it to your dotfiles repository, too.
 
 ## Build & Installation
 


### PR DESCRIPTION
`GITHUB_TOKEN` is precious and should be handled carefully, avoid the risks of exposing it. Updated the readme with a warning and an `alias` to suggest a better experience.